### PR TITLE
fix: Resolve react-query devtools peer dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     ]
   },
   "devDependencies": {
-    "gh-pages": "^4.0.0",
-    "react-query-devtools": "^2.6.3"
+    "gh-pages": "^4.0.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-// import { ReactQueryDevtools } from 'react-query-devtools';
+import { ReactQueryDevtools } from 'react-query/devtools'; // Corrected import
 import './App.css';
 import Layout from './components/NewLayout/Layout';
 import { ThemeProvider } from './contexts/ThemeContext'; // Import ThemeProvider
@@ -15,6 +15,8 @@ const App = () => {
           <ThemeProvider> {/* Wrap Layout with ThemeProvider */}
              <Layout/>
           </ThemeProvider>
+          {/* Conditionally render ReactQueryDevtools */}
+          {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     )
   


### PR DESCRIPTION
Removes the standalone `react-query-devtools` package from devDependencies, as it was causing a peer dependency conflict with `react-query@3.x`.

Updates `App.js` to import `ReactQueryDevtools` directly from `react-query/devtools` and conditionally renders them only in development mode. This resolves the `ERESOLVE` error in the CI build.