### PR TITLE
fix(ci): Set NODE_OPTIONS to fix OpenSSL compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           npm ci
           npm run build
+        env: # ADDED THIS SECTION
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.3.3


### PR DESCRIPTION
Adds NODE_OPTIONS=--openssl-legacy-provider to the build step in the CI workflow. This is to ensure compatibility with older OpenSSL versions implicitly required by dependencies when using Node.js 17+ (including Node 20.x used in recent runners), resolving the 'ERR_OSSL_EVP_UNSUPPORTED' error during `npm run build`.