### PR TITLE
fix(ci): Add clean option to gh-pages deploy step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,4 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: build # The folder the action should deploy.
           token: ${{ secrets.MY_TOKEN }}
+          clean: true # ADDED THIS LINE


### PR DESCRIPTION
Adds `clean: true` to the JamesIves/github-pages-deploy-action configuration. This will remove existing files from the `gh-pages` branch before deploying new content, which can help prevent errors related to conflicting Git history or worktree issues.